### PR TITLE
Allow node 7.x on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
   matrix:
     - nodejs_version: "4"
     - nodejs_version: "6"
+    - nodejs_version: "7"
 
 branches:
   only:


### PR DESCRIPTION
Windows users have been getting `WARNING: Node v7.9.0 is not tested against Ember CLI on your platform. We recommend that you use the most-recent "Active LTS" version of Node.js.` even on the latest version because `appveyor.yml` versions was not updated when `travis.yml` was.